### PR TITLE
Fix use of uninitialized variable in File_scanner_OFF.h

### DIFF
--- a/Stream_support/include/CGAL/IO/OFF/File_scanner_OFF.h
+++ b/Stream_support/include/CGAL/IO/OFF/File_scanner_OFF.h
@@ -535,7 +535,7 @@ public:
     //split it into strings
     std::istringstream iss(col);
     //holds the rgb values
-    unsigned char rgb[3];
+    unsigned char rgb[3]{};
     int index =0;
     //split the string into numbers
     while(iss>>color_info){


### PR DESCRIPTION
## Summary of Changes

Fix CWE-457: Use of Uninitialized Variable in File_scanner_OFF.h

If the function `get_color_from_line`, is called with the input stream containing only `#`, the while loop will exit at the break condition, the index will be 0 (i.e `index<2`) and `rgb[0]` will be dereferenced in the call to `get_indexed_color`. Since rgb is never initialised this could lead to undefined behaviour.

## Release Management

* Affected package(s): 3D Polyhedral Surface
* Issue(s) solved (if any):security/bugfix
* License and copyright ownership: Returned to CGAL authors